### PR TITLE
Added optional 'host' parameter.

### DIFF
--- a/lib/src/Connection.dart
+++ b/lib/src/Connection.dart
@@ -199,7 +199,7 @@ xml:lang='en'
     connectionNegotatiorManager =
         ConnectionNegotatiorManager(this, account.password);
     try {
-      return await Socket.connect(account.domain, account.port).then((Socket socket) {
+      return await Socket.connect(account.host ?? account.domain, account.port).then((Socket socket) {
         _socket = socket;
         socket
             .cast<List<int>>()

--- a/lib/src/account/XmppAccountSettings.dart
+++ b/lib/src/account/XmppAccountSettings.dart
@@ -6,12 +6,13 @@ class XmppAccountSettings {
   String domain;
   String resource = "";
   String password;
+  String host;
   int port;
   int totalReconnections = 3;
   int reconnectionTimeout = 1000;
   bool ackEnabled = true;
 
-  XmppAccountSettings(this.name, this.username, this.domain, this.password, this.port);
+  XmppAccountSettings(this.name, this.username, this.domain, this.password, this.port, {this.host});
 
   Jid get fullJid => Jid(username, domain, resource);
 


### PR DESCRIPTION
Added 'host' parameter as optional is XmppAccountSettings.
It is useful when the domain name and the host server are different.