### PR TITLE
Fix processing ServiceDiscovery info during second login.

### DIFF
--- a/lib/src/features/Negotiator.dart
+++ b/lib/src/features/Negotiator.dart
@@ -50,6 +50,11 @@ abstract class ConnectionNegotiator {
   bool isReady() {
     return _state != NegotiatorState.DONE && state != NegotiatorState.DONE_CLEAN_OTHERS;
   }
+
+  @override
+  String toString() {
+    return '{name: ${expectedName}, name_space: ${expectedNameSpace}, priority: ${priorityLevel}, state: ${state}}, isReady: ${isReady()}';
+  }
 }
 
 enum NegotiatorState { IDLE, NEGOTIATING, DONE, DONE_CLEAN_OTHERS }

--- a/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
+++ b/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
@@ -76,6 +76,8 @@ class ServiceDiscoveryNegotiator extends ConnectionNegotiator {
       state = NegotiatorState.NEGOTIATING;
       subscription = _connection.inStanzasStream.listen(_parseStanza);
       _sendServiceDiscoveryRequest();
+    } else if (state == NegotiatorState.DONE){
+      _connection.setState(XmppConnectionState.DoneServiceDiscovery);
     }
   }
 

--- a/lib/src/features/streammanagement/StreamManagmentModule.dart
+++ b/lib/src/features/streammanagement/StreamManagmentModule.dart
@@ -152,7 +152,7 @@ class StreamManagementModule extends ConnectionNegotiator {
     }
     timer = Timer.periodic(
         Duration(milliseconds: 5000), (Timer t) => sendAckRequest());
-    inStanzaSubscription = _connection.outStanzasStream.listen(parseOutStanza);
+    outStanzaSubscription = _connection.outStanzasStream.listen(parseOutStanza);
     inStanzaSubscription = _connection.inStanzasStream.listen(parseInStanza);
   }
 


### PR DESCRIPTION
During second login to the chat we already know about available `Feature`s and `Identity`es and we don't need request them again. We can just navigate to next state if this info was requested and saved before.