### PR TITLE
Removed the creation new 'negotiatorStateStreamController' every time after closing;

### DIFF
--- a/lib/src/features/Negotiator.dart
+++ b/lib/src/features/Negotiator.dart
@@ -22,9 +22,6 @@ abstract class Negotiator {
   set state(NegotiatorState value) {
     _state = value;
     negotiatorStateStreamController.add(state);
-    if (state == NegotiatorState.DONE) {
-      negotiatorStateStreamController.close();
-    }
   }
 
   String get expectedNameSpace => _expectedNameSpace;
@@ -45,9 +42,6 @@ abstract class Negotiator {
   void negotiate(List<Nonza> nonza);
 
   void backToIdle() {
-    if (negotiatorStateStreamController.isClosed) {
-      negotiatorStateStreamController = StreamController();
-    }
     state = NegotiatorState.IDLE;
   }
 


### PR DESCRIPTION
@vukoye I suggest not close `negotiatorStateStreamController` after completing the processing feature. Because after creating a new instance of this controller not all old listeners will receive events about the changing state of `Negotiator`. I found some issues after the reconnection process when the next new connections did not follow the right connection flow. If I mistake, please fix me, maybe I did not correctly understand processing features in your lib. Best regards))) 