### PR TITLE
Added dispose and removeInstance to Connection

### DIFF
--- a/lib/src/ReconnectionManager.dart
+++ b/lib/src/ReconnectionManager.dart
@@ -12,10 +12,12 @@ class ReconnectionManager {
   late int timeOutInMs;
   int counter = 0;
   Timer? timer;
+  late StreamSubscription<XmppConnectionState> _xmppConnectionStateSubscription;
 
   ReconnectionManager(Connection connection) {
     _connection = connection;
-    _connection.connectionStateStream.listen(connectionStateHandler);
+    _xmppConnectionStateSubscription =
+        _connection.connectionStateStream.listen(connectionStateHandler);
     initialTimeout = _connection.account.reconnectionTimeout;
     totalReconnections = _connection.account.totalReconnections;
     timeOutInMs = initialTimeout;
@@ -50,5 +52,10 @@ class ReconnectionManager {
     } else {
       _connection.close();
     }
+  }
+
+  void close() {
+    timer?.cancel();
+    _xmppConnectionStateSubscription.cancel();
   }
 }

--- a/lib/src/extensions/ping/PingManager.dart
+++ b/lib/src/extensions/ping/PingManager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:xmpp_stone/src/elements/stanzas/AbstractStanza.dart';
 import 'package:xmpp_stone/src/elements/stanzas/IqStanza.dart';
 import 'package:xmpp_stone/src/Connection.dart';
@@ -8,9 +10,14 @@ class PingManager {
 
   static final Map<Connection, PingManager> _instances = {};
 
+  late StreamSubscription<XmppConnectionState> _xmppConnectionStateSubscription;
+  late StreamSubscription<AbstractStanza?> _abstractStanzaSubscription;
+
   PingManager(this._connection) {
-    _connection.connectionStateStream.listen(_connectionStateProcessor);
-    _connection.inStanzasStream.listen(_processStanza);
+    _xmppConnectionStateSubscription =
+        _connection.connectionStateStream.listen(_connectionStateProcessor);
+    _abstractStanzaSubscription =
+        _connection.inStanzasStream.listen(_processStanza);
   }
 
   static PingManager getInstance(Connection connection) {
@@ -20,6 +27,12 @@ class PingManager {
       _instances[connection] = manager;
     }
     return manager;
+  }
+
+  static void removeInstance(Connection connection) {
+    _instances[connection]?._abstractStanzaSubscription.cancel();
+    _instances[connection]?._xmppConnectionStateSubscription.cancel();
+    _instances.remove(connection);
   }
 
   void _connectionStateProcessor(XmppConnectionState event) {

--- a/lib/src/features/servicediscovery/CarbonsNegotiator.dart
+++ b/lib/src/features/servicediscovery/CarbonsNegotiator.dart
@@ -29,11 +29,16 @@ class CarbonsNegotiator extends Negotiator {
     return instance;
   }
 
+  static void removeInstance(Connection connection) {
+    _instances[connection]?._subscription?.cancel();
+    _instances.remove(connection);
+  }
+
   final Connection _connection;
 
   bool enabled = false;
 
-  late StreamSubscription<AbstractStanza?> _subscription;
+  StreamSubscription<AbstractStanza?>? _subscription;
   late IqStanza _myUnrespondedIqStanza;
 
   CarbonsNegotiator(this._connection) {
@@ -72,7 +77,7 @@ class CarbonsNegotiator extends Negotiator {
     if (stanza is IqStanza && stanza.id == _myUnrespondedIqStanza.id) {
       enabled = stanza.type == IqStanzaType.RESULT;
       state = NegotiatorState.DONE;
-      _subscription.cancel();
+      _subscription?.cancel();
     }
   }
 }

--- a/lib/src/features/servicediscovery/MAMNegotiator.dart
+++ b/lib/src/features/servicediscovery/MAMNegotiator.dart
@@ -25,9 +25,14 @@ class MAMNegotiator extends Negotiator {
     return instance;
   }
 
+  static void removeInstance(Connection connection) {
+    _instances[connection]?._subscription?.cancel();
+    _instances.remove(connection);
+  }
+
   late IqStanza _myUnrespondedIqStanza;
 
-  late StreamSubscription<AbstractStanza?> _subscription;
+  StreamSubscription<AbstractStanza?>? _subscription;
 
   final Connection _connection;
 
@@ -111,7 +116,7 @@ class MAMNegotiator extends Negotiator {
         });
       }
       state = NegotiatorState.DONE;
-      _subscription.cancel();
+      _subscription?.cancel();
     }
   }
 

--- a/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
+++ b/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
@@ -28,9 +28,14 @@ class ServiceDiscoveryNegotiator extends Negotiator {
     return instance;
   }
 
+  static void removeInstance(Connection connection) {
+    _instances[connection]?.subscription?.cancel();
+    _instances.remove(connection);
+  }
+
   IqStanza? fullRequestStanza;
 
-  late StreamSubscription<AbstractStanza?> subscription;
+  StreamSubscription<AbstractStanza?>? subscription;
 
   final Connection _connection;
 
@@ -111,7 +116,7 @@ class ServiceDiscoveryNegotiator extends Negotiator {
         _errorStreamController.add(errorStanza);
       }
     }
-    subscription.cancel();
+    subscription?.cancel();
     _connection.connectionNegotatiorManager.addFeatures(_supportedFeatures);
     state = NegotiatorState.DONE;
   }

--- a/lib/src/messages/MessageHandler.dart
+++ b/lib/src/messages/MessageHandler.dart
@@ -23,6 +23,10 @@ class MessageHandler implements MessageApi {
     return manager;
   }
 
+  static void removeInstance(Connection connection) {
+    instances.remove(connection);
+  }
+
   final Connection _connection;
 
   MessageHandler(this._connection);


### PR DESCRIPTION
Here is my answer to https://github.com/vukoye/xmpp_dart/issues/59

- A new `dispose()` method for Connection which calls `close()` but then goes on to remove references to any instances of various Manager and other instances create in relation to a Connection instance.

- New `close()` or static `removeInstance` for the various Managers and Modules which mainly cancels any `Timer` and `StreamSubscription` active in those instances. Then deletes the instance from the static `instances` maps of each class.

- A new `removeInstance` static method for `Connection` which can be called in addition to `dispose()` if the `Connection` instance was created using `getInstance` instead of the standard `Connection` constructor.

I should point out that there is no breaking changes as the above additions can be completely ignored and the package used like it was so far. The `close()` method of `Connection` remains unchanged.

I added a description to `dispose()` to indicate it is not a replacement for `close()' and is not suitable when the connection is expected to be re-used later.

@vukoye Hopefully the above makes sense but you may have another idea so would love to hear it. I'm not sure all of the additions are strictly necessary but I found it quite difficult to pinpoint which active references was keeping the Connection instances from being garbage collected. What I know for sure is that after calling dispose() my connections get properly garbage collected.