### PR TITLE
Support Anonymous Auth

### DIFF
--- a/lib/src/features/sasl/AnonymousHandler.dart
+++ b/lib/src/features/sasl/AnonymousHandler.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:crypto/crypto.dart';
+import 'package:xmpp_stone/src/Connection.dart';
+import 'package:xmpp_stone/src/elements/XmppAttribute.dart';
+import 'package:xmpp_stone/src/elements/nonzas/Nonza.dart';
+import 'package:xmpp_stone/src/features/sasl/AbstractSaslHandler.dart';
+import 'package:xmpp_stone/src/features/sasl/SaslAuthenticationFeature.dart';
+
+import '../../logger/Log.dart';
+
+class AnonymousHandler implements AbstractSaslHandler {
+  static const TAG = 'AnonymousHandler';
+
+  final Connection _connection;
+  late StreamSubscription<Nonza> subscription;
+  final _completer = Completer<AuthenticationResult>();
+  ScramStates _scramState = ScramStates.INITIAL;
+
+  final SaslMechanism _mechanism;
+
+  String? _mechanismString;
+
+  late var serverSignature;
+
+  AnonymousHandler(this._connection, this._mechanism) {
+    initMechanism();
+  }
+
+  @override
+  Future<AuthenticationResult> start() {
+    subscription = _connection.inNonzasStream.listen(_parseAnswer);
+    sendInitialMessage();
+    return _completer.future;
+  }
+
+  void initMechanism() {
+    if (_mechanism == SaslMechanism.ANONYMOUS) {
+      _mechanismString = 'ANONYMOUS';
+    }
+  }
+
+  void sendInitialMessage() {
+    var nonza = Nonza();
+    nonza.name = 'auth';
+    nonza.addAttribute(
+        XmppAttribute('xmlns', 'urn:ietf:params:xml:ns:xmpp-sasl'));
+    nonza.addAttribute(XmppAttribute('mechanism', _mechanismString));
+    _scramState = ScramStates.AUTH_SENT;
+    _connection.writeNonza(nonza);
+  }
+
+  void _parseAnswer(Nonza nonza) {
+    if (_scramState == ScramStates.AUTH_SENT) {
+      if (nonza.name == 'failure') {
+        _fireAuthFailed('Auth Error in challenge');
+      } else if (nonza.name == 'success') {
+        subscription.cancel();
+        _completer.complete(AuthenticationResult(true, ''));
+      }
+    }
+  }
+
+  void _fireAuthFailed(String message) {
+    Log.e(TAG, message);
+    subscription.cancel();
+    _completer.complete(AuthenticationResult(false, message));
+  }
+}
+
+enum ScramStates {
+  INITIAL,
+  AUTH_SENT,
+}

--- a/lib/src/features/sasl/SaslAuthenticationFeature.dart
+++ b/lib/src/features/sasl/SaslAuthenticationFeature.dart
@@ -5,6 +5,7 @@ import 'package:xmpp_stone/src/features/Negotiator.dart';
 import 'package:xmpp_stone/src/features/sasl/AbstractSaslHandler.dart';
 import 'package:xmpp_stone/src/features/sasl/PlainSaslHandler.dart';
 import 'package:xmpp_stone/src/features/sasl/ScramSaslHandler.dart';
+import 'package:xmpp_stone/src/features/sasl/AnonymousHandler.dart';
 
 import '../../elements/nonzas/Nonza.dart';
 
@@ -19,6 +20,7 @@ class SaslAuthenticationFeature extends Negotiator {
     _supportedMechanisms.add(SaslMechanism.SCRAM_SHA_1);
     _supportedMechanisms.add(SaslMechanism.SCRAM_SHA_256);
     _supportedMechanisms.add(SaslMechanism.PLAIN);
+    _supportedMechanisms.add(SaslMechanism.ANONYMOUS);
     expectedName = 'SaslAuthenticationFeature';
   }
 
@@ -53,6 +55,9 @@ class SaslAuthenticationFeature extends Negotiator {
       case SaslMechanism.SCRAM_SHA_1_PLUS:
         break;
       case SaslMechanism.EXTERNAL:
+        break;
+      case SaslMechanism.ANONYMOUS:
+        saslHandler = AnonymousHandler(_connection, mechanism);
         break;
       case SaslMechanism.NOT_SUPPORTED:
         break;
@@ -89,6 +94,9 @@ class SaslAuthenticationFeature extends Negotiator {
         case 'SCRAM-SHA-1':
           _offeredMechanisms.add(SaslMechanism.SCRAM_SHA_1);
           break;
+        case 'ANONYMOUS':
+          _offeredMechanisms.add(SaslMechanism.ANONYMOUS);
+          break;
         case 'PLAIN':
           _offeredMechanisms.add(SaslMechanism.PLAIN);
           break;
@@ -110,5 +118,6 @@ enum SaslMechanism {
   SCRAM_SHA_1,
   SCRAM_SHA_256,
   PLAIN,
+  ANONYMOUS,
   NOT_SUPPORTED
 }


### PR DESCRIPTION
1. Add ANONYMOUS as supported mechanism
2. Add AnonymousHandler that requests SASL ANONYMOUS:
```
<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='ANONYMOUS'/>
```

Completes auth if success:
```
<success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/>
```

Source:
https://xmpp.org/extensions/xep-0175.html