### PR TITLE
bug fix to xep-0030 support

### DIFF
--- a/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
+++ b/lib/src/features/servicediscovery/ServiceDiscoveryNegotiator.dart
@@ -142,10 +142,12 @@ class ServiceDiscoveryNegotiator extends Negotiator {
     //iqStanza.fromJid = _connection.fullJid; //do not send for now
     iqStanza.toJid = request.fromJid;
     var query = XmppElement();
+    query.name = 'query';
     query.addAttribute(XmppAttribute('xmlns', NAMESPACE_DISCO_INFO));
     SERVICE_DISCOVERY_SUPPORT_LIST.forEach((featureName) {
       var featureElement = XmppElement();
-      featureElement.addAttribute(XmppAttribute('feature', featureName));
+      featureElement.name = 'feature';
+      featureElement.addAttribute(XmppAttribute('var', featureName));
       query.addChild(featureElement);
     });
     iqStanza.addChild(query);


### PR DESCRIPTION
As https://xmpp.org/extensions/xep-0030.html described,
feature value should be in `var` attribute of feature element.
And query element name tag is missing

# Changes
- fix missing query element name
- fix missing feature element name
- fix feature attribute name